### PR TITLE
Workers js files in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,43 @@
 The [Ajax.org Cloud9 Editor (Ace)](https://github.com/ajaxorg/ace) for the Rails 3.1+ asset
 pipeline.
 
-## Usage
+## Installation
 
-`Gemfile`:
+In your Gemfile, add:
 
 ```ruby
 gem 'ace-rails-ap'
 ```
 
-`application.js`:
+Then execute `bundle` and restart your server.
+
+Add in your application.js file:
 
 ```javascript
-//= require ace/ace
-//= require ace/worker-html
+//= require ace-rails-ap
 ```
 
-To include a theme or mode, put:
+To include a theme or mode, add them in your application.js file:
 
 ```javascript
 //= require ace/theme-sometheme
 //= require ace/mode-somemode
 ```
 
-...in your `application.js` manifest as well.
+Do not include Ace workers files in your application.js file. Then just use Ace like normal.
 
-Then just use Ace like normal.
+## Rails Asset Pipeline
+
+Ace editor will dynamically load in run-time the workers javascript files.
+ace-rails-ap play nice with rails asset pipeline by automatically configuring the precompilation of the workers files,
+and by setting-up Ace to load the fingerprinted worker files. You have nothing to do, it just works.
+
+## Migrate from previous version of ace-rails-ap
+
+You may have done some customisation to allow ace-rails-ap to work in production, such as adding the worker files in
+`assets.precompile` of your application.rb and/or using `ace.config.setModuleUrl` function. You can remove those.
+
+Also replace the previous javascript manifest instruction `//= require ace/ace` by the new `//= require ace-rails-ap`, and remove
+all workers from your javascript manifest.
+
 

--- a/lib/ace/rails/engine.rb
+++ b/lib/ace/rails/engine.rb
@@ -1,6 +1,9 @@
 module Ace
   module Rails
     class Engine < ::Rails::Engine
+      initializer 'ace-rails-ap.assets.precompile' do |app|
+        app.config.assets.precompile += %w[ace/worker-*.js]
+      end
     end
   end
 end

--- a/vendor/assets/javascripts/ace-rails-ap.js
+++ b/vendor/assets/javascripts/ace-rails-ap.js
@@ -1,0 +1,2 @@
+//= require ace/ace
+//= require set_ace_paths

--- a/vendor/assets/javascripts/set_ace_paths.js.erb
+++ b/vendor/assets/javascripts/set_ace_paths.js.erb
@@ -1,0 +1,5 @@
+ace.config.set('basePath', '/assets/ace');
+<% Dir[File.dirname(__FILE__) + '/ace/worker-*.js'].each do |file| %>
+<% worker = File.basename(file, '.js').sub(/^worker-/, '') %>
+ace.config.setModuleUrl("ace/mode/<%= worker %>_worker", "<%= asset_path "ace/worker-#{worker}.js" %>");
+<% end %>


### PR DESCRIPTION
Fix problems for worker files for ace editor in production (and also in test if you are using Selenium features). 

What it does:
- add all workers files to the asset pipeline (will generate fingerprinted files during precompilation)
- set-up Ace `basePath` to find its files in assets path
- set-up Ace to use fingerprinted files for dynamic loading of the workers

How to use:
- Update your Gemfile to use this commit
- remove all patches, tricks, and other workaround you implemented to have ace compile and wrk in production
  - remove all Ace related `assets.precompile` instructions you may use previously to fix the workers problems in production
  - remove any `ace.config.set('basePath', ...);` instruction you may use previously to fix the path  problem in development
  - remove any `ace.config.setModuleUrl(...)` instruction you may use previously to fix the workers problems in production
  - remove all worker file from the javascript manifest
- replace `//= require ace/ace` by `//= require ace-rails-ap` in the javascript manifest
- `bundle`, restart server

It automatically detect all workers files, so if Ace team add workers they will be taken into account with no further coding. Though it assume that all workers files are located in "vendor/assets/javascripts/ace/" path, and if the Ace team decide to change that path we will have to adapt our code.

Cheers