### PR TITLE
Allow modes to be lazily loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ To include a theme or mode, add them in your application.js file:
 //= require ace/mode-somemode
 ```
 
-Do not include Ace workers files in your application.js file. Then just use Ace like normal.
+Workers and modes don't need to be included in your application.js file, as they can also be loaded dynamically (see below).
 
 ## Rails Asset Pipeline
 
-Ace editor will dynamically load in run-time the workers javascript files.
-ace-rails-ap play nice with rails asset pipeline by automatically configuring the precompilation of the workers files,
-and by setting-up Ace to load the fingerprinted worker files. You have nothing to do, it just works.
+Ace will dynamically load the JavaScript files for workers and modes at run-time.
+
+ace-rails-ap plays nicely with the Rails asset pipeline by automatically configuring the precompilation of the workers and modes,
+and by setting up Ace to load the fingerprinted files. You have nothing to do, it just works.
 
 ## Migrate from previous version of ace-rails-ap
 
@@ -41,5 +42,3 @@ You may have done some customisation to allow ace-rails-ap to work in production
 
 Also replace the previous javascript manifest instruction `//= require ace/ace` by the new `//= require ace-rails-ap`, and remove
 all workers from your javascript manifest.
-
-

--- a/lib/ace/rails/engine.rb
+++ b/lib/ace/rails/engine.rb
@@ -2,7 +2,7 @@ module Ace
   module Rails
     class Engine < ::Rails::Engine
       initializer 'ace-rails-ap.assets.precompile' do |app|
-        app.config.assets.precompile += %w[ace/worker-*.js]
+        app.config.assets.precompile += %w[ace/worker-*.js ace/mode-*.js]
       end
     end
   end

--- a/vendor/assets/javascripts/set_ace_paths.js.erb
+++ b/vendor/assets/javascripts/set_ace_paths.js.erb
@@ -3,3 +3,7 @@ ace.config.set('basePath', '/assets/ace');
 <% worker = File.basename(file, '.js').sub(/^worker-/, '') %>
 ace.config.setModuleUrl("ace/mode/<%= worker %>_worker", "<%= asset_path "ace/worker-#{worker}.js" %>");
 <% end %>
+<% Dir[File.dirname(__FILE__) + '/ace/mode-*.js'].each do |file| %>
+<% mode = File.basename(file, '.js').sub(/^mode-/, '') %>
+ace.config.setModuleUrl("ace/mode/<%= mode %>", "<%= asset_path "ace/mode-#{mode}.js" %>");
+<% end %>


### PR DESCRIPTION
The modes files are 6 MB of JavaScript, so requiring them all in the
main application.js isn't practical for sites that want to support all
modes.

@codykrieger this would fix https://github.com/codykrieger/ace-rails-ap/issues/13, is it something you'd be interested in adding? It will need a README update if that's the case.