### PR TITLE
Sort the Ace Workers and Modes So Order Is Maintained

### DIFF
--- a/vendor/assets/javascripts/set_ace_paths.js.erb
+++ b/vendor/assets/javascripts/set_ace_paths.js.erb
@@ -1,9 +1,9 @@
 ace.config.set('basePath', '/assets/ace');
-<% Dir[File.dirname(__FILE__) + '/ace/worker-*.js'].sort { |file1, file2| file1 <=> file2 }.each do |file| %>
+<% Dir[File.dirname(__FILE__) + '/ace/worker-*.js'].sort.each do |file| %>
 <% worker = File.basename(file, '.js').sub(/^worker-/, '') %>
 ace.config.setModuleUrl("ace/mode/<%= worker %>_worker", "<%= asset_path "ace/worker-#{worker}.js" %>");
 <% end %>
-<% Dir[File.dirname(__FILE__) + '/ace/mode-*.js'].sort { |file1, file2| file1 <=> file2 }.each do |file| %>
+<% Dir[File.dirname(__FILE__) + '/ace/mode-*.js'].sort.each do |file| %>
 <% mode = File.basename(file, '.js').sub(/^mode-/, '') %>
 ace.config.setModuleUrl("ace/mode/<%= mode %>", "<%= asset_path "ace/mode-#{mode}.js" %>");
 <% end %>

--- a/vendor/assets/javascripts/set_ace_paths.js.erb
+++ b/vendor/assets/javascripts/set_ace_paths.js.erb
@@ -1,9 +1,9 @@
 ace.config.set('basePath', '/assets/ace');
-<% Dir[File.dirname(__FILE__) + '/ace/worker-*.js'].each do |file| %>
+<% Dir[File.dirname(__FILE__) + '/ace/worker-*.js'].sort { |file1, file2| file1 <=> file2 }.each do |file| %>
 <% worker = File.basename(file, '.js').sub(/^worker-/, '') %>
 ace.config.setModuleUrl("ace/mode/<%= worker %>_worker", "<%= asset_path "ace/worker-#{worker}.js" %>");
 <% end %>
-<% Dir[File.dirname(__FILE__) + '/ace/mode-*.js'].each do |file| %>
+<% Dir[File.dirname(__FILE__) + '/ace/mode-*.js'].sort { |file1, file2| file1 <=> file2 }.each do |file| %>
 <% mode = File.basename(file, '.js').sub(/^mode-/, '') %>
 ace.config.setModuleUrl("ace/mode/<%= mode %>", "<%= asset_path "ace/mode-#{mode}.js" %>");
 <% end %>


### PR DESCRIPTION
Hi,

I discovered this when upgrading our app to Rails 5 with Sprockets 3.6.3. Essentially, because the files  shown in the p/r were not being sorted, it was resulting in js that was inconsistent (ie: the files were getting iterated over in random order). As a result, when running rake assets:precompile across multiple server instances, it resulted in the manifest ace was included in having a different fingerprint from server instance to server instance.

Hope this helps someone else :)