### PR TITLE
Allow mode selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ You may have done some customisation to allow ace-rails-ap to work in production
 
 Also replace the previous javascript manifest instruction `//= require ace/ace` by the new `//= require ace-rails-ap`, and remove
 all workers from your javascript manifest.
+
+## Limiting asset build to certain modes
+
+By default, all mode files are included in the asset build. If you want to limit the asset build to only those modes which you will use, create an initializer like the following:
+
+```ruby
+Ace::Rails.include_modes = %w{html yaml}
+```

--- a/lib/ace/rails/engine.rb
+++ b/lib/ace/rails/engine.rb
@@ -1,8 +1,18 @@
 module Ace
   module Rails
+    mattr_accessor :include_modes
+
     class Engine < ::Rails::Engine
       initializer 'ace-rails-ap.assets.precompile' do |app|
-        app.config.assets.precompile += %w[ace/worker-*.js ace/mode-*.js]
+        app.config.assets.precompile +=
+          if Ace::Rails.include_modes.present?
+            Ace::Rails.include_modes.each_with_object([]) { |mode, assets|
+              assets << "ace/worker-#{mode}-*.js"
+              assets << "ace/mode-#{mode}-*.js"
+            }
+          else
+            %w[ace/worker-*.js ace/mode-*.js]
+          end
       end
     end
   end

--- a/vendor/assets/javascripts/set_ace_paths.js.erb
+++ b/vendor/assets/javascripts/set_ace_paths.js.erb
@@ -1,9 +1,33 @@
 ace.config.set('basePath', '/assets/ace');
-<% Dir[File.dirname(__FILE__) + '/ace/worker-*.js'].sort.each do |file| %>
+<%
+  if Ace::Rails.include_modes.present?
+    Ace::Rails.include_modes.each do |worker|
+%>
+ace.config.setModuleUrl("ace/mode/<%= worker %>_worker", "<%= asset_path "ace/worker-#{worker}.js" %>");
+<%
+    end
+  else
+    Dir[File.dirname(__FILE__) + '/ace/worker-*.js'].sort.each do |file|
+%>
 <% worker = File.basename(file, '.js').sub(/^worker-/, '') %>
 ace.config.setModuleUrl("ace/mode/<%= worker %>_worker", "<%= asset_path "ace/worker-#{worker}.js" %>");
-<% end %>
-<% Dir[File.dirname(__FILE__) + '/ace/mode-*.js'].sort.each do |file| %>
+<%
+    end
+  end
+%>
+<%
+  if Ace::Rails.include_modes.present?
+    Ace::Rails.include_modes.each do |mode|
+%>
+      ace.config.setModuleUrl("ace/mode/<%= mode %>", "<%= asset_path "ace/mode-#{mode}.js" %>");
+<%
+    end
+  else
+    Dir[File.dirname(__FILE__) + '/ace/mode-*.js'].sort.each do |file|
+%>
 <% mode = File.basename(file, '.js').sub(/^mode-/, '') %>
 ace.config.setModuleUrl("ace/mode/<%= mode %>", "<%= asset_path "ace/mode-#{mode}.js" %>");
-<% end %>
+<%
+    end
+  end
+%>


### PR DESCRIPTION
The default build includes all mode files, but we'd prefer to keep our asset build small, so I added an option to specify which modes to prebuild. If you don't set this option, the current behavior is maintained.

LMK if I've misunderstood anything. Thanks!